### PR TITLE
fix(apis): Ensure response.content is treated as a string on both Py versions

### DIFF
--- a/authorize/apis/transaction.py
+++ b/authorize/apis/transaction.py
@@ -1,5 +1,6 @@
 from decimal import Decimal
 import requests
+import six
 
 from authorize.exceptions import AuthorizeConnectionError, \
     AuthorizeResponseError
@@ -40,7 +41,7 @@ class TransactionAPI(object):
 
     def _make_call(self, params):
         response = requests.post(self.url, data=params)
-        fields = parse_response(response.content)
+        fields = parse_response(six.ensure_str(response.content))
         if fields['response_code'] != '1':
             e = AuthorizeResponseError('%s full_response=%r' %
                 (fields['response_reason_text'], fields))


### PR DESCRIPTION
I think this finally fixes the problem